### PR TITLE
citeseerx webapp: fix abstract in search result page

### DIFF
--- a/src/java/edu/psu/citeseerx/web/SearchController.java
+++ b/src/java/edu/psu/citeseerx/web/SearchController.java
@@ -292,8 +292,8 @@ public class SearchController implements Controller {
         }
 	
         // Standard addons
-        queryString.append("&hl=true&wt=json");
-        
+        queryString.append("&hl=true&hl.fragsize=0&wt=json");
+
         // Now, we add specific parameters to each type of search
         if (queryType.equals(DOCUMENT_QUERY)) {
             if ((Boolean)queryParameters.get(INCLUDE_CITATIONS) == false) {

--- a/web/citeseerx_webapp/WEB-INF/jsp/csx/searchDocs.jsp
+++ b/web/citeseerx_webapp/WEB-INF/jsp/csx/searchDocs.jsp
@@ -57,7 +57,7 @@
                 <c:if test="${ hit.inCollection }">
                   <c:if test="${ ! empty hit['abstract'] }">
                   <div class="pubabstract">
-                    <c:out value="${ hit['abstract']}"/>
+                    <c:out value="${ hit['abstract']}" escapeXml="false"/>
                   </div>
                   </c:if>
                 </c:if>

--- a/web/citeseerx_webapp/css/results.css
+++ b/web/citeseerx_webapp/css/results.css
@@ -56,6 +56,10 @@
   color: #333;
 }
 
+.pubabstract em {
+  font-weight: bold;
+}
+
 .pubtools {
 	position: relative;
 	width: 100%;


### PR DESCRIPTION
The problem is that the <em> tag has been escaped.

http://pychuang-blog.logdown.com/posts/245277-fix-abstract-toggle-in-serp-of-citeseerx
