### PR TITLE
citeseerx webapp: set hl.fragsize to 300 in a Solr query

### DIFF
--- a/src/java/edu/psu/citeseerx/web/SearchController.java
+++ b/src/java/edu/psu/citeseerx/web/SearchController.java
@@ -292,7 +292,7 @@ public class SearchController implements Controller {
         }
 	
         // Standard addons
-        queryString.append("&hl=true&hl.fragsize=0&wt=json");
+        queryString.append("&hl=true&hl.fragsize=300&wt=json");
 
         // Now, we add specific parameters to each type of search
         if (queryType.equals(DOCUMENT_QUERY)) {


### PR DESCRIPTION
It is not good to let Solr return whole data in highlighting, especially for text field.  We should give it a limit anyway.
