### PR TITLE
change csx_logo size in IncludeHeader.jsp

### DIFF
--- a/web/citeseerx_webapp/WEB-INF/jsp/shared/IncludeHeader.jsp
+++ b/web/citeseerx_webapp/WEB-INF/jsp/shared/IncludeHeader.jsp
@@ -60,5 +60,5 @@
 	<div id="wrapper">
   	<%@ include file="IncludeTopNav.jsp" %>
 	  <div id="header">
-			<h1 id="title"><a href="<c:url value='/'/>" title="<fmt:message key="app.name"/>"><img src="<c:url value='/images/csx_logo.png'/>" alt="<fmt:message key="app.name"/> logo" /></a></h1>
+			<h1 id="title"><a href="<c:url value='/'/>" title="<fmt:message key="app.name"/>"><img src="<c:url value='/images/csx_logo.png'/>" alt="<fmt:message key="app.name"/> logo" height="50%" width="50%"/></a></h1>
 		</div>


### PR DESCRIPTION
change csx_logo size to 50% of the current image size, so it does not appear too big on search result page and document summary page