### PR TITLE
delete ResponseStatus method in ViewDocController.java

### DIFF
--- a/src/java/edu/psu/citeseerx/web/ViewDocController.java
+++ b/src/java/edu/psu/citeseerx/web/ViewDocController.java
@@ -51,13 +51,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@ResponseStatus(value = HttpStatus.NOT_FOUND)
-class ResourceNotFoundException extends RuntimeException {
-       public ResourceNotFoundException(String doi) {
-             int httpstatus = 404; 
-       }
-}
-
 /**
  * Provides model objects to document summary view.
  * @author Isaac Councill


### PR DESCRIPTION
It was a method used to added to return 404, but was not working. Since it is not used at all, it should be deleted to clean the code. No test is necessary at this point as long as compiling is OK.
