### PR TITLE
Wip solr upgrade

### DIFF
--- a/resources/solr/schema.xml
+++ b/resources/solr/schema.xml
@@ -136,6 +136,7 @@
    <field name="text" type="text" indexed="true" stored="false" termVectors="true" termOffsets="true" termPositions="true" />
    <field name="cites" type="tokens" indexed="true" stored="false" omitNorms="true"/>
    <field name="citedby" type="tokens" indexed="true" stored="false" omitNorms="true"/>
+   <field name="vtime" type="tlong" indexed="true" stored="true" omitNorms="true"/>
    <field name="timestamp" type="date" indexed="true" stored="true" default="NOW" multiValued="false"/>
 
    <!--

--- a/resources/solr/solrconfig.xml
+++ b/resources/solr/solrconfig.xml
@@ -849,7 +849,7 @@
       <str name="wt">json</str>
       <str name="df">text</str>
       <str name="fl">
-        id,doi,incol,title,author,abstract,year,venue,ncites,scites
+        id,doi,incol,title,author,abstract,year,venue,ncites,scites,vtime
       </str>
 
       <str name="defType">edismax</str>

--- a/src/java/edu/psu/citeseerx/updates/IndexUpdateManager.java
+++ b/src/java/edu/psu/citeseerx/updates/IndexUpdateManager.java
@@ -290,6 +290,7 @@ public class IndexUpdateManager {
         String year = doc.getDatum(Document.YEAR_KEY, Document.ENCODED);
         String abs = doc.getDatum(Document.ABSTRACT_KEY, Document.ENCODED);
         String text = getText(doc);
+        long vtime = (doc.getVersionTime() != null) ? doc.getVersionTime().getTime() : 0;
         int ncites = doc.getNcites();
         int scites = doc.getSelfCites();
 
@@ -374,6 +375,7 @@ public class IndexUpdateManager {
 
         solrDoc.addField("cites", citesBuffer.toString());
         solrDoc.addField("citedby", citedbyBuffer.toString());
+        solrDoc.addField("vtime", Long.toString(vtime));
 
         return solrDoc;
     } //- buildSolrInputDocument

--- a/src/java/edu/psu/citeseerx/updates/IndexUpdateManager.java
+++ b/src/java/edu/psu/citeseerx/updates/IndexUpdateManager.java
@@ -89,8 +89,10 @@ public class IndexUpdateManager {
     private URL solrUpdateUrl;
 
     public void setSolrURL(String solrUpdateUrl) throws MalformedURLException {
+        int cpus = Runtime.getRuntime().availableProcessors();
+
         this.solrUpdateUrl = new URL(solrUpdateUrl);
-        this.solrServer = new ConcurrentUpdateSolrServer(solrUpdateUrl, 1000, 16);
+        this.solrServer = new ConcurrentUpdateSolrServer(solrUpdateUrl, indexBatchSize, cpus);
     } //- setSolrURL
 
 
@@ -114,7 +116,9 @@ public class IndexUpdateManager {
     private ExecutorService threadPool;
 
     {
-        threadPool = Executors.newFixedThreadPool(16);
+        int cpus = Runtime.getRuntime().availableProcessors();
+
+        threadPool = Executors.newFixedThreadPool(cpus * 2);
     }
 
     /**


### PR DESCRIPTION
This pull request includes two commits.

1) IndexUpdateManager: get number of processors dynamically

This is one of the suggestions from Kyle in the code review last time

2) solr schema: add field vtime back

This is to fix a bug in the new schema -- we removed a field vtime which is used in "sort by recency"