### PR TITLE
changed url for semantic scholar

### DIFF
--- a/web/citeseerx_webapp/WEB-INF/jsp/csx/shared/IncludeResultsSidebar.jsp
+++ b/web/citeseerx_webapp/WEB-INF/jsp/csx/shared/IncludeResultsSidebar.jsp
@@ -18,7 +18,7 @@
 
   <div id="qother">Try your query at:
     <c:url value='http://scholar.google.com/scholar' var="googleScholar"><c:param name='q' value='${ param.q }'/><c:param name='hl' value='en' /><c:param name='btnG' value='Search'/></c:url>
-    <c:url value='http://s2.allenai.org/search' var='s2'><c:param name='q' value='${ param.q }'/></c:url>
+    <c:url value='https://www.semanticscholar.org/search' var='s2'><c:param name='q' value='${ param.q }'/></c:url>
     <c:url value='http://dblp.uni-trier.de/search' var='dblp'><c:param name='q' value='${ param.q }'/></c:url>
     <c:url value='http://www.bing.com/search' var="Bing"><c:param name="q" value='${ param.q }'/></c:url>
     <c:url value='https://www.google.com/search' var="Google"><c:param name="q" value='${ param.q }'/></c:url>

--- a/web/citeseerx_webapp/WEB-INF/jsp/shared/IncludeSearchBox.jsp
+++ b/web/citeseerx_webapp/WEB-INF/jsp/shared/IncludeSearchBox.jsp
@@ -45,7 +45,7 @@
 	   	<label>Documents:</label>
 	     <input class="s_field" type="text" name="q" value="<c:out value='${ query }'/>" />
 	     <input class="s_button" type="image" name="submit" value="Search" alt="Search" src="<c:url value='/images/search_icon.png' />" onclick='this.form.action="<c:url value='/search' />"; return true;' />
-	     <input class="s_button" type="image" name="s2" value="Semantic Scholar" alt="Semantic Scholar" src="<c:url value='/images/s2_icon.png' />" onclick="this.form.action='http://s2.allenai.org/search'; return true;" />
+	     <input class="s_button" type="image" name="s2" value="Semantic Scholar" alt="Semantic Scholar" src="<c:url value='/images/s2_icon.png' />" onclick="this.form.action='https://www.semanticscholar.org/search'; return true;" />
 			 <div class="opts">
 		     <a href="<c:url value='/advanced_search'/>" title="Search full text, title, abstract, date, author name, author affiliation, etc.">Advanced Search</a>
 		     <input class="c_box" type="checkbox" name="ic" value="1" <c:if test='${ ! empty param.ic }'>checked="checked"</c:if> /> Include Citations


### PR DESCRIPTION
`Try your query at:` redirects to wrong page, semantic scholar URL has changed. 